### PR TITLE
Add ark view connection method registration

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,33 @@
+.onLoad <- function(libname, pkgname) {
+  register_ark_methods()
+}
+
+register_ark_methods <- function() {
+  tryCatch(
+    {
+      register <- get(".ark.register_method", envir = globalenv())
+
+      register(
+        "ark_positron_variable_has_viewer",
+        "connConnection",
+        function(x) TRUE
+      )
+
+      register(
+        "ark_positron_variable_kind",
+        "connConnection",
+        function(x) "connection"
+      )
+
+      register(
+        "ark_positron_variable_view",
+        "connConnection",
+        function(x) {
+          connection_view(x)
+          TRUE
+        }
+      )
+    },
+    error = function(e) {}
+  )
+}


### PR DESCRIPTION
## Summary
- Adds `zzz.R` with `.onLoad()` to register S3 methods with Positron's ark
- Enables viewing `connConnection` objects from the Variables pane via the Connections pane
- Registers three methods: `ark_positron_variable_has_viewer`, `ark_positron_variable_kind`, `ark_positron_variable_view`

Requires https://github.com/posit-dev/ark/pull/1014 before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)